### PR TITLE
Add optional aria-label attributes to header navigation. Fixes #130.

### DIFF
--- a/src/data/data.yml
+++ b/src/data/data.yml
@@ -47,10 +47,12 @@ site_nav:
         - text: Career Outcomes
           url: /institute/advancing-your-career/outcomes
         - text: Events
+          label: Career Events
           url: /institute/advancing-your-career/events
         - text: For Employers
           url: /institute/advancing-your-career/employers
         - text: Meet the Team
+          label: Meet the Careers Team
           url: /institute/advancing-your-career/team
     - text: Academics
       url: /institute/academics
@@ -152,6 +154,7 @@ site_nav:
       url: /institute/student-life
       items:
         - text: Meet the Team
+          label: Meet the Student Life Team
           url: /institute/student-life/team
         - text: New Students
           url: /institute/student-life/new-students
@@ -189,6 +192,7 @@ site_nav:
         - text: Carl Fehlandt Scholarship
           url: /institute/giving/carl-fehlandt-scholarship
         - text: Meet the Team
+          label: Meet the Giving Team
           url: /institute/giving/team
 
 footer_nav:

--- a/src/templates/partials/nav.twig
+++ b/src/templates/partials/nav.twig
@@ -8,7 +8,7 @@
       {% endif %}
 
       <li class="site-nav__item" data-nav-item>
-        <a href="{{item.url}}" class="site-nav__link" data-nav-link>
+        <a href="{{item.url}}"{% if item.label %} aria-label="{{item.label}}"{% endif %} class="site-nav__link" data-nav-link>
           {{item.text}}
 
           {% if has_sub_nav %}


### PR DESCRIPTION
In order to meet WCAG guideline 2.4.4, we need to ensure there is a unique label for each link which has a different URL. A few items in our site header navigation have the same label, but different URLs. To resolve this, we can add an `aria-label` attribute to the link with different text which accessibility software will read in place of the default text, but which will not have any visible effect.

This is what the HTML will look like:

`<a href="/institute/advancing-your-career/events" aria-label="Career Events" class="site-nav__link" data-nav-link> Events </a>`

@kettlestitch and @dmorter Please make sure that the label text I've added for each of the items is appropriate.

@zebapy Let me know if you'd prefer to handle this in the frontend code differently.