### PR TITLE
Provide a class to separate secondary from primary navigation menus in sidebars. For #163.

### DIFF
--- a/src/scss/components/_page-nav.scss
+++ b/src/scss/components/_page-nav.scss
@@ -52,7 +52,7 @@
   }
 }
 
-.page-nav__list--callouts {
+.page-nav__list--callouts, .page-nav__list--secondary {
   border-top: 4px solid #cfd5db;
   margin-top: 1.5rem;
   padding-top: 1.5rem;


### PR DESCRIPTION
This will allow me to apply the border separation class used for the callouts menu in the main Institute newsroom without adopting the list styles which are applied to that menu.